### PR TITLE
Association refset component validation

### DIFF
--- a/scripts/file-centric/file-centric-snapshot-association-valid-targetcomponentid.sql
+++ b/scripts/file-centric/file-centric-snapshot-association-valid-targetcomponentid.sql
@@ -3,7 +3,7 @@
 	file-centric-snapshot-association-valid-targetcomponentid
 
 	Assertion:
-	TargetComponentId refers to valid concepts in the ASSOCIATION REFSET snapshot file.
+	TargetComponentId refers to valid components in the ASSOCIATION REFSET snapshot file.
 
 ********************************************************************************/
 	insert into qa_result (runid, assertionuuid, concept_id, details, component_id, table_name)
@@ -16,7 +16,10 @@
 		'curr_associationrefset_s'
 	from curr_associationrefset_s a
 	left join curr_concept_s b
-	on a.targetcomponentid = b.id
-	where b.id is null;
+		on a.targetcomponentid = b.id
+    left join curr_description_s c
+        on a.targetcomponentid = c.id
+    left join curr_relationship_s d
+        on a.targetcomponentid = d.id
+	where b.id is null and c.id is null and d.id is null;
 	commit;
-	

--- a/scripts/file-centric/file-centric-snapshot-association-valid-targetcomponentid.sql
+++ b/scripts/file-centric/file-centric-snapshot-association-valid-targetcomponentid.sql
@@ -11,15 +11,39 @@
 		<RUNID>,
 		'<ASSERTIONUUID>',
 		a.referencedcomponentid,
-		concat('ASSOC RS: Targetcomponentid=',a.targetcomponentid, ':Invalid TargetComponentId.'),
+		concat('ASSOC RS: Targetcomponentid=',a.targetcomponentid, ':Invalid TargetComponentId. RefsetId=', a.refsetid),
+		a.id,
+		'curr_associationrefset_s'
+	from curr_associationrefset_s a
+	left join curr_concept_s b
+		on a.targetcomponentid = b.id
+	where b.id is null
+		and a.refsetid in 
+			(900000000000523009, /* POSSIBLY EQUIVALENT TO */
+			900000000000528000, /* WAS A */
+			900000000000530003, /* ALTERNATIVE */
+			900000000000531004) /* REFERS TO */;
+	commit;
+
+	insert into qa_result (runid, assertionuuid, concept_id, details, component_id, table_name)
+	select 
+		<RUNID>,
+		'<ASSERTIONUUID>',
+		a.referencedcomponentid,
+		concat('ASSOC RS: Targetcomponentid=',a.targetcomponentid, ':Invalid TargetComponentId. RefsetId=', a.refsetid),
 		a.id,
 		'curr_associationrefset_s'
 	from curr_associationrefset_s a
 	left join curr_concept_s b
 		on a.targetcomponentid = b.id
 	left join curr_description_s c
-        	on a.targetcomponentid = c.id
+        on a.targetcomponentid = c.id
 	left join curr_relationship_s d
 		on a.targetcomponentid = d.id
-	where b.id is null and c.id is null and d.id is null;
+	where b.id is null and c.id is null and d.id is null
+		and a.refsetid not in 
+			(900000000000523009, /* POSSIBLY EQUIVALENT TO */
+			900000000000528000, /* WAS A */
+			900000000000530003, /* ALTERNATIVE */
+			900000000000531004) /* REFERS TO */;
 	commit;

--- a/scripts/file-centric/file-centric-snapshot-association-valid-targetcomponentid.sql
+++ b/scripts/file-centric/file-centric-snapshot-association-valid-targetcomponentid.sql
@@ -17,9 +17,9 @@
 	from curr_associationrefset_s a
 	left join curr_concept_s b
 		on a.targetcomponentid = b.id
-    left join curr_description_s c
-        on a.targetcomponentid = c.id
-    left join curr_relationship_s d
-        on a.targetcomponentid = d.id
+	left join curr_description_s c
+        	on a.targetcomponentid = c.id
+	left join curr_relationship_s d
+		on a.targetcomponentid = d.id
 	where b.id is null and c.id is null and d.id is null;
 	commit;


### PR DESCRIPTION
According to https://confluence.ihtsdotools.org/display/DOCRELFMT/5.2.5.1+Historical+Association+Reference+Sets association reference sets such as REPLACED BY can refer to any component, not just concepts that this test is limited to.

This change expands this test to consider references to descriptions and relationships as valid too, this is necessary for the Australian Extension which does refer to inactive descriptions and their replacements which appears to be in specification for RF2.