### PR TITLE
Refset descriptor test to only consider active refsets

### DIFF
--- a/scripts/resource/file-centric-refsetid-validation-proc.sql
+++ b/scripts/resource/file-centric-refsetid-validation-proc.sql
@@ -20,7 +20,7 @@ leave myloop;
 end if;
 set @component = substring_index(tb_name,'_s',1);
 set @details = CONCAT('CONCAT(\'',@component,'\',\' ::id= \',a.id,\' ::refset id: \',a.refsetid,\' is not in refset descriptor list\')');
-set @sql = CONCAT('insert into qa_result(run_id, assertion_id, concept_id, details) select ', runid,',',assertionid,',0,',@details,' from (select min(id) as id, refsetid from ', substring_index(dbname,'.',1),'.',tb_name, ' where refsetid not in (select refsetid from ',substring_index(dbname,'.',1),'.refset_id) group by refsetid) a;');
+set @sql = CONCAT('insert into qa_result(run_id, assertion_id, concept_id, details) select ', runid,',',assertionid,',0,',@details,' from (select min(id) as id, refsetid from ', substring_index(dbname,'.',1),'.',tb_name, ' where active = 1 and refsetid not in (select refsetid from ',substring_index(dbname,'.',1),'.refset_id) group by refsetid) a;');
 prepare stmt from @sql;
 execute stmt;
 drop prepare stmt;


### PR DESCRIPTION
From testing the Australian Edition we have historic retired reference sets that do not have reference set descriptor rows.

It seems pointless to add descriptor rows to retired reference sets, so I'm proposing this change which I think will only consider active reference sets when checking for reference set descriptors.